### PR TITLE
fix(ai): Automated bug fixes from BugHunterAgent in src/flask

### DIFF
--- a/src/flask/ctx.py
+++ b/src/flask/ctx.py
@@ -261,15 +261,16 @@ class AppContext:
                     exc = sys.exc_info()[1]
                 self.app.do_teardown_appcontext(exc)
         finally:
-            ctx = _cv_app.get()
-            _cv_app.reset(self._cv_tokens.pop())
+            if self._cv_tokens:
+                ctx = _cv_app.get()
+                _cv_app.reset(self._cv_tokens.pop())
 
-        if ctx is not self:
-            raise AssertionError(
-                f"Popped wrong app context. ({ctx!r} instead of {self!r})"
-            )
+                if ctx is not self:
+                    raise AssertionError(
+                        f"Popped wrong app context. ({ctx!r} instead of {self!r})"
+                    )
 
-        appcontext_popped.send(self.app, _async_wrapper=self.app.ensure_sync)
+            appcontext_popped.send(self.app, _async_wrapper=self.app.ensure_sync)
 
     def __enter__(self) -> AppContext:
         self.push()


### PR DESCRIPTION
Fixed a bug in `src/flask/ctx.py` where `AppContext.pop` could raise an `AssertionError` if called after the last token was popped. The fix guards the context reset and assertion check with a check for remaining tokens.